### PR TITLE
Returns struct for API errors

### DIFF
--- a/rest/errors.go
+++ b/rest/errors.go
@@ -1,0 +1,16 @@
+package rest
+
+import (
+	"fmt"
+)
+
+// APIError return the api error
+type APIError struct {
+	Status  int
+	Message string
+}
+
+// Error return the error message
+func (e APIError) Error() string {
+	return fmt.Sprintf("APIError: status=%d, message=%s", e.Status, e.Message)
+}

--- a/rest/request.go
+++ b/rest/request.go
@@ -86,11 +86,17 @@ func (c *Client) do(r Requester) (*fasthttp.Response, error) {
 	if res.StatusCode() != 200 {
 		var r = new(Response)
 		if err := json.Unmarshal(res.Body(), r); err != nil {
-			return nil, fmt.Errorf("faild to get data. status: %d", res.StatusCode())
+			return nil, &APIError{
+				Status:  res.StatusCode(),
+				Message: err.Error(),
+			}
 		}
 
 		if !r.Success {
-			return nil, fmt.Errorf("faild to get data. status: %d - %s", res.StatusCode(), r.Error)
+			return nil, &APIError{
+				Status:  res.StatusCode(),
+				Message: r.Error,
+			}
 		}
 	}
 	return res, nil


### PR DESCRIPTION
Allow to do something like
```
if err, ok := err.(*rest.APIError); ok && err.Status == 401 {
    //  handle 401 authentication error
}
```